### PR TITLE
AWS SDK compatibility

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
     ],
     "require": {
         "php": ">=5.3.0",
-        "guzzle/guzzle": "~3.9.0"
+        "guzzle/guzzle": "~3.7.0"
     },
     "require-dev": {
         "mockery/mockery": ">=0.7.2",


### PR DESCRIPTION
Guzzle v3.9.0+ isn't compatible with the AWS SDK. The current version of the AWS SDK supports Guzzle 3.7.4, which seems to work with the Clarify API.
